### PR TITLE
FIX: missing aws region

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,9 +80,6 @@ workflows:
             - go-tests
             - go-lint
             - helm-check
-          filters:
-            branches:
-              only: master
   release:
     jobs:
       - push-release:

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Flags:
                                  Protect pods with this annotation from eviction. May be specified multiple times.
       --ignore-safe-to-evict-annotation
                                  Ignore the "cluster-autoscaler.kubernetes.io/safe-to-evict=false" annotation.
+      --aws-region=AWS-REGION    AWS region to use for AWS ASG instance health status updates.
       --aws-set-unhealthy-on-drain
                                  Set the AWS ASG instance to unhealthy when draining a node. Requires the AWS IAM policy "autoscaling:SetInstanceHealth".
 

--- a/cmd/draino/draino.go
+++ b/cmd/draino/draino.go
@@ -94,6 +94,7 @@ func main() {
 		protectedPodAnnotations      = app.Flag("protected-pod-annotation", "Protect pods with this annotation from eviction. May be specified multiple times.").PlaceHolder("KEY[=VALUE]").Strings()
 		ingoreSafeToEvictAnnotations = app.Flag("ignore-safe-to-evict-annotation", "Ignore the cluster-autoscaler.kubernetes.io/safe-to-evict=false annotation.").Bool()
 
+		awsRegion              = app.Flag("aws-region", "AWS region to use for AWS API calls.").String()
 		awsSetUnhealthyOnDrain = app.Flag("aws-set-unhealthy-on-drain", "Marks AWS ASG instances as unhealthy during draining.").Default("false").Bool()
 
 		conditions = app.Arg("node-conditions", "Nodes for which any of these conditions are true will be cordoned and drained.").Required().Strings()
@@ -124,7 +125,7 @@ func main() {
 	var asgManager *aws.ASGManager
 	if *awsSetUnhealthyOnDrain {
 		log.Info("Initializing AWS ASG Manager to mark instances as unhealthy during drain.")
-		asgManager = aws.NewASGManager(log)
+		asgManager = aws.NewASGManager(log, *awsRegion)
 	}
 
 	c, err := kubernetes.BuildConfigFromFlags(*apiserver, *kubecfg)

--- a/internal/aws/asg.go
+++ b/internal/aws/asg.go
@@ -13,6 +13,9 @@ type ASGManager struct {
 }
 
 func NewASGManager(logger *zap.Logger, region string) *ASGManager {
+	if region == "" {
+		logger.Fatal("No AWS region specified")
+	}
 	sess, err := session.NewSession(&aws.Config{
 		Region: aws.String(region),
 	})

--- a/internal/aws/asg.go
+++ b/internal/aws/asg.go
@@ -12,12 +12,14 @@ type ASGManager struct {
 	Logger  *zap.Logger
 }
 
-func NewASGManager(logger *zap.Logger) *ASGManager {
-	sess, err := session.NewSession(&aws.Config{})
+func NewASGManager(logger *zap.Logger, region string) *ASGManager {
+	sess, err := session.NewSession(&aws.Config{
+		Region: aws.String(region),
+	})
 	if err != nil {
 		logger.Fatal("Error creating AWS session:", zap.Error(err))
 	}
-	logger.Info("AWS session created")
+	logger.Info("AWS session created", zap.String("region", region))
 	return &ASGManager{Session: sess, Logger: logger}
 }
 


### PR DESCRIPTION
```
FATAL    aws/asg.go:35    Error setting instance health:    {"error": "MissingRegion: could not find region configuration"}
```